### PR TITLE
The image mode for gray scale was not covered in final texture output…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"python.pythonPath": "/usr/local/bin/python3"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"python.pythonPath": "/usr/local/bin/python3"
+}

--- a/Source/_gltf2usd/gltf2/GLTFImage.py
+++ b/Source/_gltf2usd/gltf2/GLTFImage.py
@@ -69,7 +69,7 @@ class GLTFImage(object):
         # and when you split each channels, the img_channels array only has 2 channels but when you are trying to merge
         # all channels for temporary output, it tries to merge 3 channels.
         # In order to avoid this error, we need to cover for img mode L and LA and convert them to RGBA 
-        if img.mode == 'P' or img.mode == "LA" or img.mode == "L":
+        if img.mode == 'P' or img.mode == 'LA' or img.mode == 'L':
             img = img.convert('RGBA')
 
         # now image channels should have 3 or channels    


### PR DESCRIPTION
The image mode for grayscale was not covered in the final texture output method. It covers the palletized image but not grayscale. Grayscale would split into 2 channels hence creating out of index error when trying to merge the channels into one texture for output.